### PR TITLE
chore: default swagger setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/goorm/reinput/global/security/CorsConfig.java
+++ b/src/main/java/goorm/reinput/global/security/CorsConfig.java
@@ -1,0 +1,24 @@
+package goorm.reinput.global.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    // TODO: cors 설정. dev, prod 주소 추가 예정
+//    @Value("${cors.origin.development}")
+//    private String developmentOrigin;
+//
+//    @Value("${cors.origin.production}")
+//    private String productionOrigin;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods("OPTIONS", "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE")
+                .allowCredentials(true)
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/src/main/java/goorm/reinput/global/security/WebSecurityConfig.java
+++ b/src/main/java/goorm/reinput/global/security/WebSecurityConfig.java
@@ -1,0 +1,20 @@
+package goorm.reinput.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class WebSecurityConfig {
+    @Bean
+    public SecurityFilterChain configure(HttpSecurity http) throws Exception {
+        // TODO: Springboot 버전 업데이트에 기존에 사용했던 시큐리티 설정이 대거 변경됨. 추후 업데이트 필요
+        return http
+                .csrf().disable()
+                .formLogin().disable()
+                .build();
+    }
+}

--- a/src/main/java/goorm/reinput/global/swagger/SwaggerConfig.java
+++ b/src/main/java/goorm/reinput/global/swagger/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package goorm.reinput.global.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(info = @Info(
+        title = "Reinput API",
+        description = "2024_BEOTKKOTTHON_TEAM_24_Reinput API",
+        version = "v1.0.0"))
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openApi() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("JWT");
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
## 1. 완료 사항
swagger에 접속할 수 있게 기본적인 세팅을 완료했습니다. 추가적으로 CorsConfig, WebSecurityConfig도 기본 세팅을 완료했습니다.
<br>


## 2. 추가 사항
springsecurity 가 springboot 버전 업에 따라 기존 사용하던 코드가 deprecated 상태입니다. 
```
    @Bean
    public SecurityFilterChain configure(HttpSecurity http) throws Exception {
        // TODO: Springboot 버전 업데이트에 기존에 사용했던 시큐리티 설정이 대거 변경됨. 추후 업데이트 필요
        return http
                .csrf().disable()
                .formLogin().disable()
                .build();
    }
```
실행은 가능하지만, 추후 문제의 여지가 있어 수정할 계획입니다.

resolve: #2
