### PR TITLE
feat: 인사이트 삭제

### DIFF
--- a/src/main/java/goorm/reinput/insight/controller/InsightController.java
+++ b/src/main/java/goorm/reinput/insight/controller/InsightController.java
@@ -39,7 +39,7 @@ public class InsightController {
 
     @Operation(summary = "인사이트 상세보기", description = "유저가 인사이트의 상세정보를 확인할 때 사용하는 API")
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
-    @GetMapping()
+    @GetMapping("/{insightId}")
     public ResponseEntity<InsightResponseDto> getInsightDetail(@Parameter(hidden = true) final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
         log.info("[InsightController] getInsightDetail {} called", principalDetails.getUserId());
 
@@ -63,5 +63,14 @@ public class InsightController {
         Long userId =  principalDetails.getUserId();
         log.info("[InsightController] modifyInsight {} called", userId);
         insightService.modifyInsight(userId, insightModifyDto);
+    }
+
+    @Operation(summary = "인사이트 삭제", description = "유저가 인사이트를 삭제할 때 사용하는 API")
+    @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
+    @DeleteMapping("/{insightId}")
+    public Boolean deleteInsight(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
+        Long userId =  principalDetails.getUserId();
+        log.info("[InsightController] deleteInsight userId = {}, insightId = {} called", userId, insightId);
+        return insightService.deleteInsight(insightId);
     }
 }

--- a/src/main/java/goorm/reinput/insight/domain/Insight.java
+++ b/src/main/java/goorm/reinput/insight/domain/Insight.java
@@ -34,7 +34,7 @@ public class Insight extends BaseTimeEntity {
     @JsonBackReference
     private Folder folder;
 
-    @OneToOne(mappedBy = "insight")
+    @OneToOne(mappedBy = "insight", cascade = CascadeType.ALL, orphanRemoval = true)
     private Reminder reminder;
 
     @JsonManagedReference

--- a/src/main/java/goorm/reinput/insight/service/InsightService.java
+++ b/src/main/java/goorm/reinput/insight/service/InsightService.java
@@ -49,6 +49,15 @@ public class InsightService {
     private final HashTagRepository hashTagRepository;
     private final CustomInsightRepository customInsightRepository;
 
+    public Boolean deleteInsight(Long insightId){
+
+        Insight insight = insightRepository.findByInsightId(insightId).orElseThrow(() -> new IllegalArgumentException("insight not found"));
+
+        insightRepository.delete(insight);
+
+        return true;
+    }
+
     public void modifyInsight(Long userId, InsightModifyDto dto) {
 
         // 인사이트 내용 업데이트

--- a/src/main/java/goorm/reinput/reminder/domain/Reminder.java
+++ b/src/main/java/goorm/reinput/reminder/domain/Reminder.java
@@ -25,10 +25,10 @@ public class Reminder extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Insight insight;
 
-    @OneToOne(mappedBy = "reminder")
+    @OneToOne(mappedBy = "reminder", cascade = CascadeType.ALL, orphanRemoval = true)
     private ReminderDate reminderDate;
 
-    @OneToOne(mappedBy = "reminder")
+    @OneToOne(mappedBy = "reminder", cascade = CascadeType.ALL, orphanRemoval = true)
     private ReminderQuestion reminderQuestion;
 
     @Builder


### PR DESCRIPTION
- Insight 삭제시 hash tag, insight image, reminder 테이블이 연쇄적으로 삭제

- reminder 삭제 시 reminder date, reminder question 테이블이 연쇄적으로 삭제

위 기능을 충족시키기 위해, 부모 엔티티에서 자식을 참조하는 칼럼에 대해
`cascade = CascadeType.ALL, orphanRemoval = true` 속성을 추가하였습니다.

## 1. 완료 사항

<br>

## 2. 추가 사항

resolve #40