### PR TITLE
feat: 폴더 내 인사이트 태그로 검색하기

### DIFF
--- a/src/main/java/goorm/reinput/insight/controller/InsightController.java
+++ b/src/main/java/goorm/reinput/insight/controller/InsightController.java
@@ -73,4 +73,14 @@ public class InsightController {
         log.info("[InsightController] deleteInsight userId = {}, insightId = {} called", userId, insightId);
         return insightService.deleteInsight(insightId);
     }
+
+    @Operation(summary = "폴더 내 인사이트 태그로 검색하기", description = "폴더 내에서 검색 시 해당 검색어가 포함된 태그를 가진 모든 인사이트를 반환합니다")
+    @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
+    @GetMapping("/search/{folderId}/{tag}")
+    public ResponseEntity<List<InsightSimpleResponseDto>> getInsightList(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long folderId, final @PathVariable String tag) {
+        Long userId =  principalDetails.getUserId();
+        log.info("[InsightController] getInsightList userId = {}, folderId = {}, tag = {} called", userId, folderId, tag);
+        return ResponseEntity.ok().body(insightService.getInsightListByFolderAndTag(userId, folderId, tag));
+    }
+
 }

--- a/src/main/java/goorm/reinput/insight/service/InsightService.java
+++ b/src/main/java/goorm/reinput/insight/service/InsightService.java
@@ -49,6 +49,25 @@ public class InsightService {
     private final HashTagRepository hashTagRepository;
     private final CustomInsightRepository customInsightRepository;
 
+    public List<InsightSimpleResponseDto> getInsightListByFolderAndTag(Long userId, Long folderId, String tag) {
+        // 폴더 ID로 Insight 리스트 조회
+        List<Insight> insightList = customInsightRepository.findByInsightFolderId(folderId).orElseGet(Collections::emptyList);
+
+        // Insight 리스트에서 각 Insight의 hashTagList를 확인하여 주어진 태그를 부분적으로 포함하는 Insight만 필터링
+        List<InsightSimpleResponseDto> filteredInsightList = insightList.stream()
+                .filter(insight -> insight.getHashTagList().stream()
+                        .anyMatch(hashTag -> hashTag.getHashTagName().toLowerCase().contains(tag.toLowerCase())))
+                .map(insight -> new InsightSimpleResponseDto(
+                        insight.getInsightId(),
+                        insight.getInsightMainImage(),
+                        insight.getInsightTitle(),
+                        insight.getInsightSummary(),
+                        insight.getHashTagList().stream().map(HashTag::getHashTagName).collect(Collectors.toList())
+                ))
+                .collect(Collectors.toList());
+
+        return filteredInsightList;
+    }
     public Boolean deleteInsight(Long insightId){
 
         Insight insight = insightRepository.findByInsightId(insightId).orElseThrow(() -> new IllegalArgumentException("insight not found"));


### PR DESCRIPTION
- 폴더 내에서 유저가 검색을 하면 해당 검색어가 포함된 태그를 가진 모든 인사이트를 반환합니다.
- 예를 들어, 인사이트 1번의 tag가 "aws", 인사이트 2번의 tag가 "awsEC2" 라면 검색어가 "aws" 인 경우 인사이트 1,2를 모두 반환합니다.

## 1. 완료 사항
![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_BE/assets/84257033/a585459d-af84-4425-837f-646c13a16357)

<br>

## 2. 추가 사항

resolve #42 