### PR TITLE
feat: 링크 og:image 제공

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //jsoup
+    implementation 'org.jsoup:jsoup:1.15.3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/goorm/reinput/insight/controller/InsightController.java
+++ b/src/main/java/goorm/reinput/insight/controller/InsightController.java
@@ -8,7 +8,6 @@ import goorm.reinput.insight.domain.dto.InsightSimpleResponseDto;
 import goorm.reinput.insight.service.InsightService;
 import goorm.reinput.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -32,7 +31,7 @@ public class InsightController {
     @Operation(summary = "인사이트 저장", description = "유저가 인사이트를 등록할 때 사용하는 API")
     @ApiResponses({@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @PostMapping()
-    public void saveInsight(@Parameter(hidden = true) final @AuthenticationPrincipal PrincipalDetails principalDetails, final @Valid @RequestBody InsightCreateDto insightCreateDto) {
+    public void saveInsight(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @Valid @RequestBody InsightCreateDto insightCreateDto) {
         log.info("[InsightController] saveInsight {} called", principalDetails.getUserId());
         insightService.saveInsight(principalDetails.getUserId(), insightCreateDto);
     }
@@ -40,7 +39,7 @@ public class InsightController {
     @Operation(summary = "인사이트 상세보기", description = "유저가 인사이트의 상세정보를 확인할 때 사용하는 API")
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @GetMapping("/{insightId}")
-    public ResponseEntity<InsightResponseDto> getInsightDetail(@Parameter(hidden = true) final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
+    public ResponseEntity<InsightResponseDto> getInsightDetail(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
         log.info("[InsightController] getInsightDetail {} called", principalDetails.getUserId());
 
         // 인사이트 리스트 반환
@@ -68,10 +67,11 @@ public class InsightController {
     @Operation(summary = "인사이트 삭제", description = "유저가 인사이트를 삭제할 때 사용하는 API")
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @DeleteMapping("/{insightId}")
-    public Boolean deleteInsight(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
+    public ResponseEntity<Boolean> deleteInsight(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
         Long userId =  principalDetails.getUserId();
         log.info("[InsightController] deleteInsight userId = {}, insightId = {} called", userId, insightId);
-        return insightService.deleteInsight(insightId);
+        return ResponseEntity.ok().body(insightService.deleteInsight(insightId));
+
     }
 
     @Operation(summary = "폴더 내 인사이트 태그로 검색하기", description = "폴더 내에서 검색 시 해당 검색어가 포함된 태그를 가진 모든 인사이트를 반환합니다")
@@ -83,4 +83,12 @@ public class InsightController {
         return ResponseEntity.ok().body(insightService.getInsightListByFolderAndTag(userId, folderId, tag));
     }
 
+    @Operation(summary = "인사이트 링크 대표 이미지 제공", description = "인사이트 첫 등록 시, 링크를 입력하면 해당 링크의 대표 이미지를 반환하는 API")
+    @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
+    @GetMapping("/ogimage")
+    public ResponseEntity<String> getMainImage(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @RequestParam("url") String url) {
+        Long userId =  principalDetails.getUserId();
+        log.info("[InsightController] getMainImage {} called, url = {}", userId, url);
+        return ResponseEntity.ok().body(insightService.getMainImage(userId, url));
+    }
 }

--- a/src/main/java/goorm/reinput/insight/service/InsightService.java
+++ b/src/main/java/goorm/reinput/insight/service/InsightService.java
@@ -25,8 +25,13 @@ import goorm.reinput.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,6 +53,20 @@ public class InsightService {
     private final InsightImageRepository insightImageRepository;
     private final HashTagRepository hashTagRepository;
     private final CustomInsightRepository customInsightRepository;
+
+    @Transactional
+    public String getMainImage(Long userId, String url) {
+        try {
+            Document doc = Jsoup.connect(url).get();
+            Elements metaOgImage = doc.select("meta[property=og:image]");
+            if (!metaOgImage.isEmpty()) {
+                return metaOgImage.first().attr("content");
+            }
+        } catch (Exception e) {
+            log.error("Error while fetching main image from URL: {}", url, e);
+        }
+        return "notExist";
+    }
 
     public List<InsightSimpleResponseDto> getInsightListByFolderAndTag(Long userId, Long folderId, String tag) {
         // 폴더 ID로 Insight 리스트 조회


### PR DESCRIPTION
- 유저가 적합한 링크를 보내면, 서버측에서 해당 링크 대표 이미지를 파싱하여 보내줍니다. 대표 이미지가 없다면, "notExist" 문자열을 보냅니다.

## 1. 완료 사항
![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_BE/assets/84257033/0804458d-486d-40d0-b655-76f4427c3be3)

파싱 url: https://brunch.co.kr/@ggwriter/55

파싱 결과: 
![ogimg](https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/9LEY/image/twsLCkTHOiEtmXIZc6b1Pj8bsPQ.png)

<br>

## 2. 추가 사항

resolve #44 