### PR TITLE
feat: 내 폴더 공유 url 생성 & url 접속하기 구현

### DIFF
--- a/src/main/java/goorm/reinput/folder/controller/FolderController.java
+++ b/src/main/java/goorm/reinput/folder/controller/FolderController.java
@@ -28,7 +28,8 @@ public class FolderController {
     }
 
     @GetMapping("/share")
-    public ResponseEntity<FolderShareResponseDto> createShareLink(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @RequestBody FolderShareDto folderShareDto) {
+    public ResponseEntity<FolderShareResponseDto> createShareLink(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestParam Long folderId, @RequestParam boolean copyable) {
+        FolderShareDto folderShareDto = new FolderShareDto(folderId, copyable);
         log.info("[FolderController] createShareLink {} called", principalDetails.getUserId());
         return ResponseEntity.ok().body(folderService.createShareLink(principalDetails.getUserId(), folderShareDto));
     }

--- a/src/main/java/goorm/reinput/folder/service/FolderService.java
+++ b/src/main/java/goorm/reinput/folder/service/FolderService.java
@@ -8,6 +8,7 @@ import goorm.reinput.folder.domain.dto.FolderShareDto;
 import goorm.reinput.folder.domain.dto.FolderShareResponseDto;
 import goorm.reinput.folder.repository.CustomFolderRepository;
 import goorm.reinput.folder.repository.FolderRepository;
+import goorm.reinput.global.util.AESUtil;
 import goorm.reinput.insight.domain.HashTag;
 import goorm.reinput.insight.domain.Insight;
 import goorm.reinput.insight.domain.InsightImage;
@@ -174,9 +175,14 @@ public class FolderService {
             throw new IllegalArgumentException("folder not found with id " + folderShareDto.getFolderId());
         }
 
-        //todo : create share link
+        String toEncrypt = folderShareDto.getFolderId() + "@" + folderShareDto.isCopyable();
+        String encryptedString = AESUtil.encrypt(toEncrypt);
+
+        //TODO 도메인으로 변경요망
+        String baseURL = "http://localhost:8080";
+
         return FolderShareResponseDto.builder()
-                .url(String.format("http://reinput.online/folder/share/%d/%s", folderShareDto.getFolderId(), folderShareDto.isCopyable()))
+                .url(String.format("%s/insight/share?token=%s", baseURL, encryptedString))
                 .build();
     }
 

--- a/src/main/java/goorm/reinput/global/util/AESUtil.java
+++ b/src/main/java/goorm/reinput/global/util/AESUtil.java
@@ -1,0 +1,44 @@
+package goorm.reinput.global.util;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+public class AESUtil {
+
+    private static final String KEY = "encryptionIntKey"; // 16자리 비밀키
+    private static final String INIT_VECTOR = "encryptionIntVec"; // 16자리 초기화 벡터
+
+    public static String encrypt(String value) {
+        try {
+            IvParameterSpec iv = new IvParameterSpec(INIT_VECTOR.getBytes("UTF-8"));
+            SecretKeySpec skeySpec = new SecretKeySpec(KEY.getBytes("UTF-8"), "AES");
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+            cipher.init(Cipher.ENCRYPT_MODE, skeySpec, iv);
+
+            byte[] encrypted = cipher.doFinal(value.getBytes());
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
+
+    public static String decrypt(String encrypted) {
+        try {
+            IvParameterSpec iv = new IvParameterSpec(INIT_VECTOR.getBytes("UTF-8"));
+            SecretKeySpec skeySpec = new SecretKeySpec(KEY.getBytes("UTF-8"), "AES");
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+            cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv);
+            byte[] original = cipher.doFinal(Base64.getDecoder().decode(encrypted));
+
+            return new String(original);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/java/goorm/reinput/insight/controller/InsightController.java
+++ b/src/main/java/goorm/reinput/insight/controller/InsightController.java
@@ -1,10 +1,7 @@
 package goorm.reinput.insight.controller;
 
 import goorm.reinput.global.auth.PrincipalDetails;
-import goorm.reinput.insight.domain.dto.InsightCreateDto;
-import goorm.reinput.insight.domain.dto.InsightModifyDto;
-import goorm.reinput.insight.domain.dto.InsightResponseDto;
-import goorm.reinput.insight.domain.dto.InsightSimpleResponseDto;
+import goorm.reinput.insight.domain.dto.*;
 import goorm.reinput.insight.service.InsightService;
 import goorm.reinput.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,7 +23,6 @@ import java.util.List;
 public class InsightController {
 
     private final InsightService insightService;
-    private final UserService userService;
 
     @Operation(summary = "인사이트 저장", description = "유저가 인사이트를 등록할 때 사용하는 API")
     @ApiResponses({@ApiResponse(responseCode = "201"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
@@ -50,7 +46,7 @@ public class InsightController {
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @GetMapping("/folder/{folderId}")
     public ResponseEntity<List<InsightSimpleResponseDto>> getInsightList(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long folderId) {
-        Long userId =  principalDetails.getUserId();
+        Long userId = principalDetails.getUserId();
         log.info("[InsightController] getInsightList userId = {}, folderId = {} called", userId, folderId);
         return ResponseEntity.ok().body(insightService.getInsightList(userId, folderId));
     }
@@ -59,7 +55,7 @@ public class InsightController {
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @PutMapping()
     public void modifyInsight(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @Valid @RequestBody InsightModifyDto insightModifyDto) {
-        Long userId =  principalDetails.getUserId();
+        Long userId = principalDetails.getUserId();
         log.info("[InsightController] modifyInsight {} called", userId);
         insightService.modifyInsight(userId, insightModifyDto);
     }
@@ -68,7 +64,7 @@ public class InsightController {
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @DeleteMapping("/{insightId}")
     public ResponseEntity<Boolean> deleteInsight(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long insightId) {
-        Long userId =  principalDetails.getUserId();
+        Long userId = principalDetails.getUserId();
         log.info("[InsightController] deleteInsight userId = {}, insightId = {} called", userId, insightId);
         return ResponseEntity.ok().body(insightService.deleteInsight(insightId));
 
@@ -78,7 +74,7 @@ public class InsightController {
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @GetMapping("/search/{folderId}/{tag}")
     public ResponseEntity<List<InsightSimpleResponseDto>> getInsightList(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @PathVariable Long folderId, final @PathVariable String tag) {
-        Long userId =  principalDetails.getUserId();
+        Long userId = principalDetails.getUserId();
         log.info("[InsightController] getInsightList userId = {}, folderId = {}, tag = {} called", userId, folderId, tag);
         return ResponseEntity.ok().body(insightService.getInsightListByFolderAndTag(userId, folderId, tag));
     }
@@ -87,8 +83,18 @@ public class InsightController {
     @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
     @GetMapping("/ogimage")
     public ResponseEntity<String> getMainImage(final @AuthenticationPrincipal PrincipalDetails principalDetails, final @RequestParam("url") String url) {
-        Long userId =  principalDetails.getUserId();
+        Long userId = principalDetails.getUserId();
         log.info("[InsightController] getMainImage {} called, url = {}", userId, url);
         return ResponseEntity.ok().body(insightService.getMainImage(userId, url));
     }
+
+    @Operation(summary = "공유된 폴더 url 접속하기", description = "유저의 폴더 내 인사이트 리스트를 볼 수 있는 url에 접속합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
+    @GetMapping("/share")
+    public ResponseEntity<List<InsightShareResponseDto>> accessSharedFolder(final @AuthenticationPrincipal PrincipalDetails principalDetails, @RequestParam("token") String token) {
+        Long userId = principalDetails.getUserId();
+        log.info("[InsightController] accessSharedFolder {} called", userId);
+        return ResponseEntity.ok().body(insightService.accessSharedFolder(userId, token));
+    }
+
 }

--- a/src/main/java/goorm/reinput/insight/domain/dto/InsightShareResponseDto.java
+++ b/src/main/java/goorm/reinput/insight/domain/dto/InsightShareResponseDto.java
@@ -1,0 +1,32 @@
+package goorm.reinput.insight.domain.dto;
+
+import goorm.reinput.reminder.domain.RemindType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class InsightShareResponseDto {
+
+    private Long insightId;
+    private String insightTitle;
+    private String insightUrl;
+    private String insightSummary;
+    private String insightMainImage;
+    private String insightMemo;
+    private String insightSource;
+    private Integer viewCount;
+    private List<String> hashTagList;
+    private List<String> insightImageList;
+
+    private String folderName;
+    private Long folderId;
+
+    private Boolean isCopyable;
+}

--- a/src/main/java/goorm/reinput/insight/repository/InsightRepository.java
+++ b/src/main/java/goorm/reinput/insight/repository/InsightRepository.java
@@ -3,9 +3,13 @@ package goorm.reinput.insight.repository;
 import goorm.reinput.insight.domain.Insight;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface InsightRepository extends JpaRepository<Insight, Long> {
     Optional<Insight> findByInsightId(Long insightId);
+    List<Insight> findByFolder_FolderId(Long folderId);
+
 }


### PR DESCRIPTION
- 기존 url 방식이 클라이언트 사이드 변조가 가능하기 때문에 암호화한 값을 전달합니다.
- 해당 url로 접속 시 폴더 내 인사이트를 보여줍니다. Reminder 관련 정보는 제공하지 않습니다.

## 1. 완료 사항
![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_BE/assets/84257033/5dfdcccb-e19a-4e20-91a5-c1800db50533)

<br>

## 2. 추가 사항

추후, 도메인을 연결하여 하단 코드의 baseURL을 수정해야합니다. 
```java
 public FolderShareResponseDto createShareLink(Long userId, FolderShareDto folderShareDto) {
        log.info("[FolderService] createShareLink {} called", userId);
        /* folder가 userId에 속하는지 확인
         없으면 exception
         있으면 share link 생성*/
        if(!folderRepository.findByFolderIdAndUser(folderShareDto.getFolderId(), userRepository.findByUserId(userId).orElseThrow()).isPresent()) {
            log.error("[FolderService] folder not found with id {}", folderShareDto.getFolderId());
            throw new IllegalArgumentException("folder not found with id " + folderShareDto.getFolderId());
        }

        String toEncrypt = folderShareDto.getFolderId() + "@" + folderShareDto.isCopyable();
        String encryptedString = AESUtil.encrypt(toEncrypt);

        //TODO 도메인으로 변경요망
        String baseURL = "http://localhost:8080";

        return FolderShareResponseDto.builder()
                .url(String.format("%s/insight/share?token=%s", baseURL, encryptedString))
                .build();
    }
```