### PR TITLE
feat: 이미지 업로드 시 url 반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     //jsoup
     implementation 'org.jsoup:jsoup:1.15.3'
 
+    // aws s3
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/goorm/reinput/global/config/StorageConfig.java
+++ b/src/main/java/goorm/reinput/global/config/StorageConfig.java
@@ -1,0 +1,32 @@
+package goorm.reinput.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class StorageConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String accessSecret;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/goorm/reinput/insight/controller/InsightController.java
+++ b/src/main/java/goorm/reinput/insight/controller/InsightController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -95,6 +96,19 @@ public class InsightController {
         Long userId = principalDetails.getUserId();
         log.info("[InsightController] accessSharedFolder {} called", userId);
         return ResponseEntity.ok().body(insightService.accessSharedFolder(userId, token));
+    }
+
+    @Operation(summary = "이미지 업로드하기", description = "유저가 이미지를 업로드 할 때 마다 이 api를 호출하면 됩니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200"), @ApiResponse(responseCode = "401"), @ApiResponse(responseCode = "403"), @ApiResponse(responseCode = "500")})
+    @PostMapping("/image")
+    public ResponseEntity<String> uploadImage(final @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                              @RequestParam("image") MultipartFile image) {
+        if (image.isEmpty()) {
+            return ResponseEntity.badRequest().body("No image file provided");
+        }
+        Long userId = principalDetails.getUserId();
+        String imageUrl = insightService.uploadImage(userId, image);
+        return ResponseEntity.ok().body(imageUrl);
     }
 
 }


### PR DESCRIPTION
- 클라이언트에서 이미지 1개를 업로드 시 마다, 해당 api를 호출하면 s3에 업로드 후 해당 이미지의 url 주소를 리턴합니다.

## 1. 완료 사항

1. 유저 토큰을 넣습니다.

![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_BE/assets/84257033/72bbcb5e-9269-4345-ac98-d3f83d7144c7)

2. key에 image를 넣고 File을 선택합니다. Value에는 사진을 업로드합니다. 
![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_24_BE/assets/84257033/31ea7942-bcf3-4e64-9336-1f1dbdfa1b28)

3. Send! 
4. 업로드한 이미지가 s3에 저장되며, 저장 후 해당 링크를 반환합니다.
<br>

## 2. 추가 사항
